### PR TITLE
Adds tdd example of a stateful text input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 .idea
 *.iml
+*.swp
+npm-debug.log

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "babel-preset-react": "^6.3.13",
     "babel-preset-stage-2": "^6.3.13",
     "chai": "^2.2.0",
+    "chance": "^1.0.3",
     "enzyme": "^2.3.0",
     "eslint": "^2.10.2",
     "eslint-plugin-react": "^5.1.1",

--- a/state/lib/text-input.js
+++ b/state/lib/text-input.js
@@ -1,11 +1,24 @@
 import React, {Component} from 'react';
 
+function onChange(event) {
+    this.setState({value: event.target.value});
+}
+
 export default class TextInput extends Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            value: ''
+        };
+    }
+
     render() {
         return (
             <input
+                onChange={onChange.bind(this)}
                 type='text'
-                value=''
+                value={this.state.value}
             />
         );
     }

--- a/state/lib/text-input.js
+++ b/state/lib/text-input.js
@@ -3,7 +3,10 @@ import React, {Component} from 'react';
 export default class TextInput extends Component {
     render() {
         return (
-            <input type='text'/>
+            <input
+                type='text'
+                value=''
+            />
         );
     }
 }

--- a/state/lib/text-input.js
+++ b/state/lib/text-input.js
@@ -1,0 +1,9 @@
+import React, {Component} from 'react';
+
+export default class TextInput extends Component {
+    render() {
+        return (
+            <input type='text'/>
+        );
+    }
+}

--- a/state/test/text-input.spec.js
+++ b/state/test/text-input.spec.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+import {expect} from 'chai';
+import TextInput from '../lib/text-input';
+
+describe('Stateful Text Input', function () {
+    let textInput;
+
+    beforeEach(function () {
+        textInput = shallow(<TextInput/>);
+    });
+
+    it('should be a text input', function () {
+        expect(textInput.type()).equals('input');
+        expect(textInput.props().type).equals('text');
+    });
+});

--- a/state/test/text-input.spec.js
+++ b/state/test/text-input.spec.js
@@ -14,4 +14,8 @@ describe('Stateful Text Input', function () {
         expect(textInput.type()).equals('input');
         expect(textInput.props().type).equals('text');
     });
+
+    it('should be empty by default', function () {
+        expect(textInput.props().value).equals('');
+    });
 });

--- a/state/test/text-input.spec.js
+++ b/state/test/text-input.spec.js
@@ -1,12 +1,15 @@
 import React from 'react';
 import {shallow} from 'enzyme';
 import {expect} from 'chai';
+import Chance from 'chance';
 import TextInput from '../lib/text-input';
 
 describe('Stateful Text Input', function () {
-    let textInput;
+    let textInput,
+        chance;
 
     beforeEach(function () {
+        chance = new Chance();
         textInput = shallow(<TextInput/>);
     });
 
@@ -17,5 +20,18 @@ describe('Stateful Text Input', function () {
 
     it('should be empty by default', function () {
         expect(textInput.props().value).equals('');
+    });
+
+    it('should update its value when text is entered', function () {
+        const newInputText = chance.string(),
+            onChangeEvent = {
+                target: {
+                    value: newInputText
+                }
+            };
+
+        textInput.simulate('change', onChangeEvent);
+
+        expect(textInput.props().value).equals(newInputText);
     });
 });


### PR DESCRIPTION
This also brings in [chancejs](http://chancejs.com/) for fuzzing the text input in tests. If bringing in this library is not wanted, this example can be refactored to use a basic string for testing.